### PR TITLE
Unit tests for PushGateway

### DIFF
--- a/src/Prometheus/CollectorRegistry.php
+++ b/src/Prometheus/CollectorRegistry.php
@@ -37,9 +37,9 @@ class CollectorRegistry
      */
     private $histograms = [];
 
-    public function __construct(Adapter $redisAdapter)
+    public function __construct(Adapter $adapter)
     {
-        $this->storageAdapter = $redisAdapter;
+        $this->storageAdapter = $adapter;
     }
 
     /**

--- a/src/Prometheus/PushGateway.php
+++ b/src/Prometheus/PushGateway.php
@@ -7,14 +7,18 @@ use GuzzleHttp\Client;
 
 class PushGateway
 {
+    private $client;
+
     private $address;
 
     /**
      * PushGateway constructor.
+     * @param $client Client 
      * @param $address string host:port of the push gateway
      */
-    public function __construct(string $address)
-    {
+    public function __construct(Client $client, string $address)
+    {       
+        $this->client = $client;
         $this->address = $address;
     }
 
@@ -67,7 +71,6 @@ class PushGateway
                 $url .= "/" . $label . "/" . $value;
             }
         }
-        $client = new Client();
         $requestOptions = [
             'headers' => [
                 'Content-Type' => RenderTextFormat::MIME_TYPE
@@ -79,7 +82,7 @@ class PushGateway
             $renderer = new RenderTextFormat();
             $requestOptions['body'] = $renderer->render($collectorRegistry->getMetricFamilySamples());
         }
-        $response = $client->request($method, $url, $requestOptions);
+        $response = $this->client->request($method, $url, $requestOptions);
         $statusCode = $response->getStatusCode();
         if ($statusCode != 202) {
             $msg = "Unexpected status code " . $statusCode . " received from pushgateway " . $this->address . ": " . $response->getBody();

--- a/tests/Test/BlackBoxPushGatewayTest.php
+++ b/tests/Test/BlackBoxPushGatewayTest.php
@@ -20,10 +20,11 @@ class BlackBoxPushGatewayTest extends \PHPUnit\Framework\TestCase
         $counter = $registry->registerCounter('test', 'some_counter', 'it increases', ['type']);
         $counter->incBy(6, ['blue']);
 
-        $pushGateway = new PushGateway('pushgateway:9091');
+        $httpClient = new Client();
+
+        $pushGateway = new PushGateway($httpClient, 'pushgateway:9091');
         $pushGateway->push($registry, 'my_job', ['instance' => 'foo']);
 
-        $httpClient = new Client();
         $metrics = $httpClient->get("http://pushgateway:9091/metrics")->getBody()->getContents();
         $this->assertContains(
             '# HELP test_some_counter it increases

--- a/tests/Test/Prometheus/PushGatewayTest.php
+++ b/tests/Test/Prometheus/PushGatewayTest.php
@@ -31,14 +31,14 @@ class PushGatewayTest extends \PHPUnit\Framework\TestCase
         $stack->push($history);        
         $client = new Client(['handler' => $stack]);
 
-        $collector_registry = new CollectorRegistry(new APC);
+        $collectorRegistry = new CollectorRegistry(new APC);
 
         $gateway = new PushGateway($client, 'mocked.pushgateway.com::1234');
         $grouping = [
             'label1' => 'val1',
             'label2' => 'val2',
         ];
-        $gateway->push($collector_registry, 'job', $grouping);
+        $gateway->push($collectorRegistry, 'job', $grouping);
         $this->assertCount(1, $container);
     }
 
@@ -57,10 +57,10 @@ class PushGatewayTest extends \PHPUnit\Framework\TestCase
         $stack->push($history);        
         $client = new Client(['handler' => $stack]);
 
-        $collector_registry = new CollectorRegistry(new APC);
+        $collectorRegistry = new CollectorRegistry(new APC);
 
         $gateway = new PushGateway($client, 'mocked.pushgateway.com::1234');
-        $gateway->pushAdd($collector_registry, 'job', []);
+        $gateway->pushAdd($collectorRegistry, 'job', []);
         $this->assertCount(1, $container);
     }
 
@@ -101,9 +101,9 @@ class PushGatewayTest extends \PHPUnit\Framework\TestCase
         $stack->push($history);        
         $client = new Client(['handler' => $stack]);
 
-        $collector_registry = new CollectorRegistry(new APC);
+        $collectorRegistry = new CollectorRegistry(new APC);
 
         $gateway = new PushGateway($client, 'mocked.pushgateway.com::1234');
-        $gateway->push($collector_registry, 'job', []);
+        $gateway->push($collectorRegistry, 'job', []);
     }
 }

--- a/tests/Test/Prometheus/PushGatewayTest.php
+++ b/tests/Test/Prometheus/PushGatewayTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Test\Prometheus;
+
+use Prometheus\PushGateway;
+use Prometheus\CollectorRegistry;
+use Prometheus\Storage\APC;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Exception\RequestException;
+
+
+class PushGatewayTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @test
+     */
+    public function itShouldPushToGateway()
+    {
+        $mock = new MockHandler([
+            new Response(202, []),
+        ]);
+
+        $container = [];
+        $history = Middleware::history($container);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);        
+        $client = new Client(['handler' => $stack]);
+
+        $collector_registry = new CollectorRegistry(new APC);
+
+        $gateway = new PushGateway($client, 'mocked.pushgateway.com::1234');
+        $grouping = [
+            'label1' => 'val1',
+            'label2' => 'val2',
+        ];
+        $gateway->push($collector_registry, 'job', $grouping);
+        $this->assertCount(1, $container);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldPushAddToGateway()
+    {
+        $mock = new MockHandler([
+            new Response(202, []),
+        ]);
+
+        $container = [];
+        $history = Middleware::history($container);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);        
+        $client = new Client(['handler' => $stack]);
+
+        $collector_registry = new CollectorRegistry(new APC);
+
+        $gateway = new PushGateway($client, 'mocked.pushgateway.com::1234');
+        $gateway->pushAdd($collector_registry, 'job', []);
+        $this->assertCount(1, $container);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldDelete()
+    {
+        $mock = new MockHandler([
+            new Response(202, []),
+        ]);
+
+        $container = [];
+        $history = Middleware::history($container);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);        
+        $client = new Client(['handler' => $stack]);
+
+        $gateway = new PushGateway($client, 'mocked.pushgateway.com::1234');
+        $gateway->delete('job', []);
+        $this->assertCount(1, $container);
+    }
+
+    /**
+     * @test
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Unexpected status code 
+     */
+    public function itShouldThrowUnexpectedStatus()
+    {
+        $mock = new MockHandler([
+            new Response(200, []),
+        ]);
+
+        $container = [];
+        $history = Middleware::history($container);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);        
+        $client = new Client(['handler' => $stack]);
+
+        $collector_registry = new CollectorRegistry(new APC);
+
+        $gateway = new PushGateway($client, 'mocked.pushgateway.com::1234');
+        $gateway->push($collector_registry, 'job', []);
+    }
+}


### PR DESCRIPTION
Refactored PushGateway to accept Http Client as a parameter in construct in order to use Mock Http Client in unit tests